### PR TITLE
Update youtube-transcript-api to use latest methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ A FastAPI-based server providing API endpoints for extracting and processing You
 
 5. Run the server:
    ```bash
-   python -m app.main
+   uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+   ```
+   
+   Alternative method:
+   ```bash
+   python run.py
    ```
 
 ### Using Docker
@@ -139,6 +144,65 @@ Response:
   "0:05 - Next caption",
   "0:10 - Another caption"
 ]
+```
+
+## Testing
+
+### Test the API with curl
+
+1. **Start the server** (in one terminal):
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+   ```
+
+2. **Test video captions endpoint**:
+   ```bash
+   curl -X POST http://localhost:8000/youtube/video-captions \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://www.youtube.com/watch?v=4AwyVTHEU3s",
+       "languages": ["en"]
+     }'
+   ```
+
+3. **Test video timestamps endpoint**:
+   ```bash
+   curl -X POST http://localhost:8000/youtube/video-timestamps \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://www.youtube.com/watch?v=4AwyVTHEU3s",
+       "languages": ["en"]
+     }'
+   ```
+
+4. **Test video metadata endpoint**:
+   ```bash
+   curl -X POST http://localhost:8000/youtube/video-data \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://www.youtube.com/watch?v=4AwyVTHEU3s"
+     }'
+   ```
+
+### Test with Python
+
+```python
+from app.utils.youtube_tools import YouTubeTools
+
+# Test transcript functionality
+test_url = 'https://www.youtube.com/watch?v=4AwyVTHEU3s'
+
+# Get captions
+captions = YouTubeTools.get_video_captions(test_url, ['en'])
+print(f"Captions: {captions[:200]}...")
+
+# Get timestamps
+timestamps = YouTubeTools.get_video_timestamps(test_url, ['en'])
+print(f"First 3 timestamps: {timestamps[:3]}")
+
+# Get video metadata
+metadata = YouTubeTools.get_video_data(test_url)
+print(f"Video title: {metadata['title']}")
 ```
 
 ## Project Structure

--- a/app/utils/youtube_tools.py
+++ b/app/utils/youtube_tools.py
@@ -4,7 +4,7 @@ from urllib.request import urlopen
 from typing import Optional, List
 
 from fastapi import HTTPException
-from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api import YouTubeTranscriptApi, NoTranscriptFound
 
 class YouTubeTools:
     @staticmethod
@@ -77,17 +77,22 @@ class YouTubeTools:
             raise HTTPException(status_code=400, detail="Error getting video ID from URL")
 
         try:
-            captions = None
-            if languages:
-                captions = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-            else:
-                captions = YouTubeTranscriptApi.get_transcript(video_id)
+            ytt_api = YouTubeTranscriptApi()
             
+            if languages:
+                captions = ytt_api.fetch(video_id, languages=languages)
+            else:
+                captions = ytt_api.fetch(video_id)
+
             if captions:
-                return " ".join(line["text"] for line in captions)
+                return " ".join(line.text for line in captions)
             return "No captions found for video"
+        except NoTranscriptFound:
+            detail = "No captions available for this video"
+            raise HTTPException(status_code=404, detail=detail)
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error getting captions for video: {str(e)}")
+            detail = f"Error getting captions for video: {str(e)}"
+            raise HTTPException(status_code=500, detail=detail)
 
     @staticmethod
     def get_video_timestamps(url: str, languages: Optional[List[str]] = None) -> List[str]:
@@ -103,12 +108,22 @@ class YouTubeTools:
             raise HTTPException(status_code=400, detail="Error getting video ID from URL")
 
         try:
-            captions = YouTubeTranscriptApi.get_transcript(video_id, languages=languages or ["en"])
+            ytt_api = YouTubeTranscriptApi()
+            
+            if languages:
+                captions = ytt_api.fetch(video_id, languages=languages)
+            else:
+                captions = ytt_api.fetch(video_id)
+
             timestamps = []
             for line in captions:
-                start = int(line["start"])
+                start = int(line.start)
                 minutes, seconds = divmod(start, 60)
-                timestamps.append(f"{minutes}:{seconds:02d} - {line['text']}")
+                timestamps.append(f"{minutes}:{seconds:02d} - {line.text}")
             return timestamps
+        except NoTranscriptFound:
+            detail = "No captions available for this video"
+            raise HTTPException(status_code=404, detail=detail)
         except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Error generating timestamps: {str(e)}")
+            detail = f"Error generating timestamps: {str(e)}"
+            raise HTTPException(status_code=500, detail=detail)


### PR DESCRIPTION
## Summary
- Update youtube-transcript-api usage from deprecated `get_transcript()` to newer `fetch()` method
- Fix object attribute access to use property notation instead of dictionary keys
- Add proper `NoTranscriptFound` exception handling with HTTP 404 responses
- Update README with comprehensive server startup and testing instructions

## Changes Made
- **app/utils/youtube_tools.py**: Updated API calls to use `ytt_api.fetch()` instead of `YouTubeTranscriptApi.get_transcript()`
- **app/utils/youtube_tools.py**: Changed `line["text"]` to `line.text` and `line["start"]` to `line.start` 
- **README.md**: Added detailed testing section with curl examples and Python testing code
- **README.md**: Updated server startup instructions to use proper uvicorn command

## Test Plan
- [x] Install dependencies with `pip install -r requirements.txt`
- [x] Test caption retrieval with sample YouTube URL
- [x] Verify timestamp generation functionality
- [x] Test API endpoints with curl commands
- [x] Validate error handling for videos without captions

🤖 Generated with [Claude Code](https://claude.ai/code)